### PR TITLE
Add KDM Settlement Manager app at /kdm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kdm-app"]
+	path = kdm-app
+	url = https://github.com/kgrimes2/kdm-settlement-manager.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,24 @@
-FROM klakegg/hugo:ext-alpine as build
+# Build the KDM React app
+FROM node:20-alpine as node-build
+
+COPY kdm-app /kdm-app
+WORKDIR /kdm-app
+
+RUN npm ci && npx vite build
+
+# Build the Hugo site
+FROM klakegg/hugo:ext-alpine as hugo-build
 
 COPY ./ /site
 WORKDIR /site
 
+# Copy the built KDM app to static directory
+COPY --from=node-build /kdm-app/dist /site/static/kdm
+
 RUN hugo
 
-#Copy static files to Nginx
+# Copy static files to Nginx
 FROM nginx:alpine
-COPY --from=build /site/public /usr/share/nginx/html
+COPY --from=hugo-build /site/public /usr/share/nginx/html
 
 WORKDIR /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- Integrates the KDM settlement manager as a web app accessible at `/kdm`
- Added kdm-settlement-manager repository as a git submodule
- Updated Docker build to compile the React app and include it in the static site

## Changes
- Add `kdm-app` submodule pointing to kdm-settlement-manager repo
- Update `Dockerfile` with multi-stage build:
  - Stage 1: Build React app with Node.js and Vite
  - Stage 2: Copy built app to Hugo static directory and run Hugo
  - Stage 3: Serve with Nginx
- Configure Vite base path to `/kdm/` for correct asset loading

## Test plan
- [x] Local Docker build completes successfully
- [x] Main Hugo site loads at root path
- [x] KDM app loads at `/kdm` path
- [x] App assets load correctly with `/kdm/` prefix
- [ ] Verify deployment to AWS Lightsail
- [ ] Test KDM app functionality at https://kevinmgrimes.com/kdm

🤖 Generated with [Claude Code](https://claude.com/claude-code)