### PR TITLE
Fix Docker build for kdm-app submodule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 # Build the KDM React app
 FROM node:20-alpine as node-build
 
-COPY kdm-app /kdm-app
+# Install git to clone the submodule
+RUN apk add --no-cache git
+
 WORKDIR /kdm-app
 
-RUN npm ci && npx vite build
+# Clone the KDM app repository
+RUN git clone https://github.com/kgrimes2/kdm-settlement-manager.git . && \
+    npm ci && \
+    npx vite build
 
 # Build the Hugo site
 FROM klakegg/hugo:ext-alpine as hugo-build


### PR DESCRIPTION
## Summary
- Fixed Docker build failure caused by missing package-lock.json from kdm-app submodule
- Updated Dockerfile to clone the kdm-app repository directly during build instead of copying from local submodule
- Ensures all necessary files are available for npm ci to run successfully

## Changes
- Added git installation to node:20-alpine build stage
- Replaced COPY command with git clone from https://github.com/kgrimes2/kdm-settlement-manager.git
- Combined clone, npm ci, and vite build into a single RUN command

## Test plan
- [ ] Docker build completes successfully
- [ ] KDM app builds and outputs to dist directory
- [ ] Hugo site includes KDM app in /kdm path
- [ ] Final nginx image serves the site correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)